### PR TITLE
feat(about): add alumni navigation button fix #15

### DIFF
--- a/src/about/AboutIcons.tsx
+++ b/src/about/AboutIcons.tsx
@@ -18,6 +18,15 @@ export const OfficerIcon = () => {
     );
 };
 
+export const AlumniIcon = () => {
+    return (
+        <svg className={iconStyle} fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5" />
+        </svg>
+
+    );
+};
+
 export const SponsorIcon = () => {
     return (
         <svg className={iconStyle} viewBox="0 0 24 24">

--- a/src/about/AboutSideNav.tsx
+++ b/src/about/AboutSideNav.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from "react-router-dom";
 import {
     InfoIcon,
     OfficerIcon,
+    AlumniIcon,
     SponsorIcon,
     PartnerIcon,
     QuestionIcon
@@ -59,6 +60,10 @@ const AboutSideNav = () => {
             <SideNavlink to="officers" currentHash={currentHash}>
                 <OfficerIcon/>
                 <SideNavtext>Officers</SideNavtext>
+            </SideNavlink>
+            <SideNavlink to="alumni" currentHash={currentHash}>
+                <AlumniIcon/>
+                <SideNavtext>Alumni</SideNavtext>
             </SideNavlink>
             <SideNavlink to="sponsors" currentHash={currentHash}>
                 <SponsorIcon/>


### PR DESCRIPTION
## Screenshots
<img width="1728" alt="Screen Shot 2023-10-18 at 11 29 13 PM" src="https://github.com/codecoogs/web/assets/91701930/539c58d7-df01-4f75-9fd2-b8b990986d4d">

## Notes
- Add alumni SVG button to about navigation side bar