### PR TITLE
Fix mobile zoom bug on card hover animations

### DIFF
--- a/src/home/About.tsx
+++ b/src/home/About.tsx
@@ -72,7 +72,7 @@ const OfficerCard = (props: OfficerCardProps) => {
 	console.log(image);
 
 	return (
-		<div className="flex flex-col bg-dark-surface-variant rounded-xl text-center p-4 hover:ring-dark-primary ring-1 ring-inset ring-white/[.3] transform transition-all hover:-translate-y-2 duration-300">
+		<div className="flex flex-col bg-dark-surface-variant rounded-xl text-center p-4 hover:ring-dark-primary ring-1 ring-inset ring-white/[.3] transition-all duration-300 card-hover-lift">
 			<div className="flex-grow">
 				<div className="w-24 h-24 md:w-32 md:h-32 mx-auto">
 					<img

--- a/src/home/Teams.tsx
+++ b/src/home/Teams.tsx
@@ -11,7 +11,7 @@ interface TeamCardProps {
 
 const TeamCard = (props: TeamCardProps) => {
 	return (
-		<li className="bg-dark-surface-variant rounded-lg text-white flex flex-col pt-2 ring-1 ring-inset ring-white/[.3] transform transition-all hover:-translate-y-2 duration-300 hover:ring-dark-primary">
+		<li className="bg-dark-surface-variant rounded-lg text-white flex flex-col pt-2 ring-1 ring-inset ring-white/[.3] transition-all duration-300 hover:ring-dark-primary card-hover-lift">
 			{props.children}
 		</li>
 	);

--- a/src/index.css
+++ b/src/index.css
@@ -73,3 +73,9 @@ html {
 		background-position: 0% 50%, 50% 50%, 100% 100%;
 	}
 }
+
+@media (hover: hover) {
+	.card-hover-lift:hover {
+		transform: translateY(-4px);
+	}
+}

--- a/src/members/Members.tsx
+++ b/src/members/Members.tsx
@@ -18,7 +18,7 @@ const MemberBenefitCard = (props: MemberBenefitCardProps) => {
 
 	return (
 		<li key={`member-benefit-${index}`}>
-			<div className="flex justify-between items-center bg-dark-surface-variant h-full rounded-lg text-center p-2 hover:ring-dark-primary transform transition-all hover:-translate-y-2 duration-300">
+			<div className="flex justify-between items-center bg-dark-surface-variant h-full rounded-lg text-center p-2 hover:ring-dark-primary transition-all duration-300 card-hover-lift">
 				<div className="flex-1 basis-1/4">
 					<CheckIcon />
 				</div>

--- a/src/officers/Officers.tsx
+++ b/src/officers/Officers.tsx
@@ -69,7 +69,7 @@ const OfficerCard = (props: OfficerCardProps) => {
 	}
 
 	return (
-		<div className="group relative flex flex-col bg-dark-surface-variant rounded-xl overflow-hidden ring-1 ring-inset ring-white/10 hover:ring-dark-primary/50 transform transition-all hover:-translate-y-1 duration-300">
+		<div className="group relative flex flex-col bg-dark-surface-variant rounded-xl overflow-hidden ring-1 ring-inset ring-white/10 hover:ring-dark-primary/50 transition-all duration-300 card-hover-lift">
 			<div className="flex flex-col flex-1 p-4 text-center">
 				{/* Avatar */}
 				<div className="w-20 h-20 md:w-24 md:h-24 mx-auto mt-2 mb-3">

--- a/src/resources/ResourceItem.tsx
+++ b/src/resources/ResourceItem.tsx
@@ -12,7 +12,7 @@ function ResourceItem(props: ResourceItemProps) {
 			to={props.link}
 			className={`${props.visible ? "visible" : "hidden"}`}
 		>
-			<div className="flex flex-col bg-dark-surface-variant rounded-xl text-center text-white p-4 hover:ring-dark-primary/50 ring-1 ring-inset ring-white/10 transform transition-all hover:-translate-y-2 duration-300">
+			<div className="flex flex-col bg-dark-surface-variant rounded-xl text-center text-white p-4 hover:ring-dark-primary/50 ring-1 ring-inset ring-white/10 transition-all duration-300 card-hover-lift">
 				<div className="w-[250px] h-[375px]">
 					<div className="mx-auto">
 						<img

--- a/src/teams/TeamsMembers.tsx
+++ b/src/teams/TeamsMembers.tsx
@@ -12,7 +12,7 @@ interface TeamCardProps {
 
 const TeamCard = (props: TeamCardProps) => {
 	return (
-		<li className="bg-dark-surface-variant rounded-lg text-white flex flex-col pt-2 ring-1 ring-inset ring-white/[.3] transform transition-all hover:-translate-y-2 duration-300 hover:ring-dark-primary">
+		<li className="bg-dark-surface-variant rounded-lg text-white flex flex-col pt-2 ring-1 ring-inset ring-white/[.3] transition-all duration-300 card-hover-lift hover:ring-dark-primary">
 			{props.children}
 		</li>
 	);


### PR DESCRIPTION
## Problem
Mobile users were experiencing website crashes when zooming in on the landing page. The bento box grid with images would break due to CSS transforms interfering with browser zoom rendering, particularly on iOS devices.

## Solution  
Applied hover effects conditionally using `@media (hover: hover)` to only apply transforms on devices that support hover states (desktops/trackpads), while keeping touch devices free from problematic CSS transforms.

## Changes
- Created reusable `card-hover-lift` CSS utility class in `src/index.css`
- Updated all card components to use the new mobile-friendly class:
  - Teams cards
  - Officer cards  
  - About/Mentor cards
  - Resource item cards
  - Member benefit cards
  - Team member cards

## Testing
- Tested on desktop with hover animations working normally
- Verified on mobile that zoom interactions work smoothly without crashes
- Cards maintain visual consistency across all screen sizes

## Related Issue
Fixes mobile crash when zooming in on landing page bento box grid